### PR TITLE
Declare WooCommerce HPOS compatibility

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,15 @@ if (!defined('WHITESTUDIOTEAM_WCPA_OPTION_GLOBAL'))  define('WHITESTUDIOTEAM_WCP
 if (!defined('WHITESTUDIOTEAM_WCPA_NONCE'))          define('WHITESTUDIOTEAM_WCPA_NONCE', 'whitestudioteam_wcpa_nonce');
 
 /**
+ * Declare compatibility with WooCommerce High-Performance Order Storage (HPOS).
+ */
+add_action('before_woocommerce_init', function () {
+        if (class_exists('\\Automattic\\WooCommerce\\Utilities\\FeaturesUtil')) {
+                \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+        }
+});
+
+/**
  * i18n – base language English, translation‑ready
  */
 function whitestudioteam_load_textdomain() {


### PR DESCRIPTION
## Summary
- declare compatibility with WooCommerce High-Performance Order Storage (HPOS)

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0b07c12148326a3424ca5b17e4302